### PR TITLE
Fix issue with color theme not working as described in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ You will need the NeoVim VScode extension installed for this to work - [Neovim E
 You can change the colors to match the theme you use:
 
 ```
-    "workbench.nvimColorNormal": "#ffc600",
-    "workbench.nvimColorInsert": "#D32F2F",
-    "workbench.nvimColorVisual": "#673AB7",
-    "workbench.nvimColorReplace": "#000"
+    "nvim-ui.nvimColorNormal": "#ffc600",
+    "nvim-ui.nvimColorInsert": "#D32F2F",
+    "nvim-ui.nvimColorVisual": "#673AB7",
+    "nvim-ui.nvimColorReplace": "#000"
 ```
 
 By default the extension only changes the color of cursor. To change the color of other elements, add it's name to workbench.nvimColorCustomizationKeys in setings.json.
@@ -36,7 +36,7 @@ By default the extension only changes the color of cursor. To change the color o
 For example, if you would like the active tab highlight and cursor to change color, enter the following in settings.json:
 
 ```
-    "workbench.nvimColorCustomizationKeys":  ["tab.activeBorder", "editorCursor.foreground"],
+    "nvim-ui.nvimColorCustomizationKeys":  ["tab.activeBorder", "editorCursor.foreground"],
 ```
 
 Here the elements that can be updated via this plugin:

--- a/src/features/changeColor/index.ts
+++ b/src/features/changeColor/index.ts
@@ -1,7 +1,5 @@
-import * as vscode from 'vscode';
-
 export function changeColor(
-  extensionConfig: any,
+  workbenchConfig: any,
   colorCustomizationKeys: string[],
   currentColorCustomizations: Record<string, string>,
   color: string
@@ -30,6 +28,6 @@ export function changeColor(
   keys.forEach((key) => (colorCustomizations[key] = color));
 
   if (currentColorCustomizations !== colorCustomizations) {
-    extensionConfig.update('colorCustomizations', colorCustomizations, true);
+    workbenchConfig.update('colorCustomizations', colorCustomizations, true);
   }
 }


### PR DESCRIPTION
Thank you for creating this wonderful extension. I discovered that the functionality for changing the color theme, as described in the README.md, doesn't work as expected. It appears that the property name in the documentation is different from the actual code. 
In this Pull Request, I suggest updating the property name in the README.md to resolve this discrepancy.

While this may not be a major issue, fixing it can potentially enhance the user experience for others.

Also, I suggest changing the parameter name in the changeColor function for better understanding and consistency.

Please let me know if you have any questions or require further changes.