### PR TITLE
Add extensionKind in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "categories": [
     "Other"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "publisher": "JulianIaquinandi",
   "activationEvents": [],
   "main": "./out/extension.js",


### PR DESCRIPTION
# Actual

When using with [dev containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, need install process for every containers.

![image](https://github.com/kensleDev/vscode-nvim-ui/assets/16986253/10bc7834-2565-46d8-839f-da4b9d38351f)

# Reference

Nvim extensions can be installed once on your local machine and used globally.

And this behavior is controlled by `extensionKind` of `package.json`.

https://github.com/vscode-neovim/vscode-neovim/blob/9bf9d34c53122ba7a0cc0f29788d53b1687b043c/package.json#L7-L10

# Thinking

If you can achieve the same behavior of "neovim extension" by just adding a few lines to `package.json`, would it be possible to merge it?

It was easy for [line_number_deco](https://github.com/ShortArrow/line_number_deco/), but [vscode-nvim-ui](https://github.com/kensleDev/vscode-nvim-ui) extension requires communication with the nvim executable file, I don't understand the internal mechanism so I can't judge whether it can be achieved in a similar way. I guess it can be done if neovim extension can do it, maybe.